### PR TITLE
Add invoice-items to API endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
     "name": "billomat-ts",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/superagent": "^4.1.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "billomat-ts",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Billomat API implementation in TypeScript for use in Node.js",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/src/billomat-resource-client.ts
+++ b/src/billomat-resource-client.ts
@@ -165,6 +165,7 @@ const SINGULAR = new Map<Billomat.ResourceName, string>([
     ['estimates', 'estimate'],
     ['incomings', 'incoming'],
     ['invoices', 'invoice'],
+    ['invoice-items', 'invoice-item'],
     ['letters', 'letter'],
     ['recurrings', 'recurring'],
     ['reminders', 'reminder'],

--- a/src/billomat.api.spec.ts
+++ b/src/billomat.api.spec.ts
@@ -31,9 +31,7 @@ const SINGULAR_OF_RESOURCE = {
 };
 
 const isImplemented = (resourceName: ResourceName): boolean =>
-    ['clients', 'client-property-values', 'confirmations', 'contacts', 'invoices', 'invoice-items'].includes(
-        resourceName
-    );
+    ['clients', 'client-property-values', 'confirmations', 'contacts', 'invoices'].includes(resourceName);
 
 describe('Billomat API', () => {
     const api = getBillomatApiClient({ baseUrl: 'billomat.net', apiKey: 'a valid key' });

--- a/src/billomat.api.spec.ts
+++ b/src/billomat.api.spec.ts
@@ -21,6 +21,7 @@ const SINGULAR_OF_RESOURCE = {
     estimates: 'estimate',
     incomings: 'incoming',
     invoices: 'invoice',
+    'invoice-items': 'invoice-item',
     letters: 'letter',
     recurrings: 'recurring',
     reminders: 'reminder',
@@ -30,7 +31,9 @@ const SINGULAR_OF_RESOURCE = {
 };
 
 const isImplemented = (resourceName: ResourceName): boolean =>
-    ['clients', 'client-property-values', 'confirmations', 'contacts', 'invoices'].includes(resourceName);
+    ['clients', 'client-property-values', 'confirmations', 'contacts', 'invoices', 'invoice-items'].includes(
+        resourceName
+    );
 
 describe('Billomat API', () => {
     const api = getBillomatApiClient({ baseUrl: 'billomat.net', apiKey: 'a valid key' });

--- a/src/get-billomat-api-client.ts
+++ b/src/get-billomat-api-client.ts
@@ -15,6 +15,7 @@ export const BILLOMAT_RESOURCE_NAMES = [
     'estimates',
     'incomings',
     'invoices',
+    'invoice-items',
     'letters',
     'recurrings',
     'reminders',
@@ -30,6 +31,7 @@ export interface MappedBillomatResourceType {
     confirmations: Billomat.Confirmation;
     contacts: Billomat.Contact;
     invoices: Billomat.Invoice;
+    'invoice-items': Billomat.InvoiceItem;
 
     [name: string]: Billomat.Resource;
 }


### PR DESCRIPTION
I added the `invoice-items` endpoint. Billomat documentation [here](https://www.billomat.com/en/api/invoices/items/). The `InvoiceItem` type was already there so this is a fairly simple PR. I also bumped the minor version.