### PR TITLE
Keep Rate Limit Statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,15 +49,15 @@ billomat.clients
 
 ## Rate Limits
 
-The Billomat-API has very strict rate limits that limit the number of requests in a specific time range. The current status of the rate limit counters and when this limit will be resetted will automatically be extracted & kept for each request. The statistics can be accessed accessed as attributes of the billomat api client:
+Billomat's API has very strict rate limits that limit the number of requests in a given time range. `billomat-ts` keeps the current status of the rate limit counters as well as the timestamp of when limits will reset for each request. The statistics can be accessed as attributes of `BillomatApiClient`:
 
-| Attribute | Description |
-|---|---|
-| `rateLimitStatistics.lastResponseAt` | Date of the last response (this is where the statistics originated) |
-| `rateLimitStatistics.limitRemaining` | Number of remaining requests |
-| `rateLimitStatistics.limitResetAt` | Date, when the rate limit will be reset |
+| Attribute                            | Description                                                        |
+| ------------------------------------ | ------------------------------------------------------------------ |
+| `rateLimitStatistics.lastResponseAt` | Date of the last response (this is where the statistics originate) |
+| `rateLimitStatistics.limitRemaining` | Number of remaining requests                                       |
+| `rateLimitStatistics.limitResetAt`   | Date when the rate limit will be reset                             |
 
-Please note: The rate limit statistics are only available after the first request.
+**Please note** that rate limit statistics are only available after the first request.
 
 ## Contact
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@ billomat.clients
 
 `billomat-ts` currently supports `list`, `get`, `create`, and `edit` operations on all known data types. The `list` functions accept query arguments, etc. In case these methods don't satisfy your requirements, you can instead use the `raw` method to perform your own requests.
 
+## Rate Limits
+
+The Billomat-API has very strict rate limits that limit the number of requests in a specific time range. The current status of the rate limit counters and when this limit will be resetted will automatically be extracted & kept for each request. The statistics can be accessed accessed as attributes of the billomat api client:
+
+| Attribute | Description |
+|---|---|
+| `rateLimitStatistics.lastResponseAt` | Date of the last response (this is where the statistics originated) |
+| `rateLimitStatistics.limitRemaining` | Number of remaining requests |
+| `rateLimitStatistics.limitResetAt` | Date, when the rate limit will be reset |
+
 ## Contact
 
 If you want to contact me you can reach me at [j-frost+billomat-ts@a3re.net](mailto:j-frost+billomat-ts@a3re.net). Also feel free to open an issue if you find a bug or have a question.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ The Billomat-API has very strict rate limits that limit the number of requests i
 | `rateLimitStatistics.limitRemaining` | Number of remaining requests |
 | `rateLimitStatistics.limitResetAt` | Date, when the rate limit will be reset |
 
+Please note: The rate limit statistics are only available after the first request.
+
 ## Contact
 
 If you want to contact me you can reach me at [j-frost+billomat-ts@a3re.net](mailto:j-frost+billomat-ts@a3re.net). Also feel free to open an issue if you find a bug or have a question.

--- a/src/billomat-resource-client.ts
+++ b/src/billomat-resource-client.ts
@@ -1,7 +1,6 @@
 import request, { SuperAgentRequest } from 'superagent';
 import { Billomat } from './billomat.js';
 import { BillomatApiClientConfig } from './get-billomat-api-client.js';
-import { RateLimitStatistics } from './get-billomat-api-client.js';
 
 export class BillomatResourceClient<T extends Billomat.Resource> {
     constructor(

--- a/src/billomat-resource-client.ts
+++ b/src/billomat-resource-client.ts
@@ -145,7 +145,7 @@ export class BillomatResourceClient<T extends Billomat.Resource> {
     private isRawResponse(o: unknown): o is Record<string, T> {
         return typeof o === 'object' && o !== null;
     }
-    
+
     private createAuthedRequest(method: string, endpoint: string): SuperAgentRequest {
         return request(method, `${this._config.baseUrl}/${endpoint}`)
             .set('Accept', 'application/json')

--- a/src/get-billomat-api-client.ts
+++ b/src/get-billomat-api-client.ts
@@ -35,7 +35,7 @@ export interface MappedBillomatResourceType {
 }
 
 export type RateLimitStatistics = {
-        lastRequestAt: Date,
+        lastResponseAt: Date,
         limitRemaining: number,
         limitResetAt: Date,
 }
@@ -48,10 +48,10 @@ export type BillomatApiClient = {
 
 export const getBillomatApiClient = (config: BillomatApiClientConfig): BillomatApiClient => {
     const rateLimitStatistics = { } as RateLimitStatistics;
-    const updateRateLimitStatistics = (stats: RateLimitStatistics) => { // Function to update the rateLimit stats.
-        rateLimitStatistics.lastRequestAt = stats.lastRequestAt;
-        rateLimitStatistics.limitRemaining = stats.limitRemaining;
-        rateLimitStatistics.limitResetAt = stats.limitResetAt;        
+    const updateRateLimitStatistics = (lastResponseAt:Date, limitRemaining:number, limitResetAt:Date) => { // Function to update the rateLimit stats.
+        rateLimitStatistics.lastResponseAt = lastResponseAt;
+        rateLimitStatistics.limitRemaining = limitRemaining;
+        rateLimitStatistics.limitResetAt = limitResetAt;        
     };
     const api = { rateLimitStatistics } as BillomatApiClient; // because we're going to modify it right below
     for (const resource of BILLOMAT_RESOURCE_NAMES) {

--- a/src/get-billomat-api-client.ts
+++ b/src/get-billomat-api-client.ts
@@ -35,14 +35,26 @@ export interface MappedBillomatResourceType {
 }
 
 export type RateLimitStatistics = {
-        lastResponseAt: Date,
-        limitRemaining: number,
-        limitResetAt: Date,
+    /**
+     * Date of the last response of which the statistics were extracted
+     */
+    lastResponseAt: Date,
+    /**
+     * Remaining number of requests
+     */
+    limitRemaining: number,
+    /**
+     * Date when the current limit is going to be reset
+     */
+    limitResetAt: Date,
 }
 
 export type BillomatApiClient = {
     [key in Billomat.ResourceName]: BillomatResourceClient<MappedBillomatResourceType[key]>;
 } & {
+    /**
+     * Provides the rate limit statistics of the last API response
+     */
     rateLimitStatistics: RateLimitStatistics;
 };
 

--- a/src/get-billomat-api-client.ts
+++ b/src/get-billomat-api-client.ts
@@ -1,5 +1,5 @@
-import { Billomat } from './billomat.js';
 import { BillomatResourceClient } from './billomat-resource-client.js';
+import { Billomat } from './billomat.js';
 
 export const BILLOMAT_RESOURCE_NAMES = [
     'activity-feed',
@@ -36,18 +36,18 @@ export interface MappedBillomatResourceType {
 
 export type RateLimitStatistics = {
     /**
-     * Date of the last response of which the statistics were extracted
+     * Timestamp of the last response when statistics were extracted
      */
-    lastResponseAt: Date,
+    lastResponseAt?: Date;
     /**
      * Remaining number of requests
      */
-    limitRemaining: number,
+    limitRemaining?: number;
     /**
      * Date when the current limit is going to be reset
      */
-    limitResetAt: Date,
-}
+    limitResetAt?: Date;
+};
 
 export type BillomatApiClient = {
     [key in Billomat.ResourceName]: BillomatResourceClient<MappedBillomatResourceType[key]>;
@@ -59,12 +59,13 @@ export type BillomatApiClient = {
 };
 
 export const getBillomatApiClient = (config: BillomatApiClientConfig): BillomatApiClient => {
-    const rateLimitStatistics = { } as RateLimitStatistics;
-    const updateRateLimitStatistics = (lastResponseAt:Date, limitRemaining:number, limitResetAt:Date) => { // Function to update the rateLimit stats.
+    const rateLimitStatistics: RateLimitStatistics = {};
+    const updateRateLimitStatistics = (lastResponseAt: Date, limitRemaining: number, limitResetAt: Date) => {
         rateLimitStatistics.lastResponseAt = lastResponseAt;
         rateLimitStatistics.limitRemaining = limitRemaining;
-        rateLimitStatistics.limitResetAt = limitResetAt;        
+        rateLimitStatistics.limitResetAt = limitResetAt;
     };
+
     const api = { rateLimitStatistics } as BillomatApiClient; // because we're going to modify it right below
     for (const resource of BILLOMAT_RESOURCE_NAMES) {
         Object.defineProperty(api, resource, {
@@ -72,11 +73,12 @@ export const getBillomatApiClient = (config: BillomatApiClientConfig): BillomatA
                 return new BillomatResourceClient<MappedBillomatResourceType[typeof resource]>(
                     config,
                     resource,
-                    updateRateLimitStatistics,
+                    updateRateLimitStatistics
                 );
             },
         });
     }
+
     return api;
 };
 


### PR DESCRIPTION
The Billomat-API has a very strict rate limit methodology. In order to increase throughput and optimized usage of the rate limit, you have to keep track of the rate limit. Luckily the API already provides statistics about the current rate limit and when this limit will be resetted. With this pull request, these statistics will be extracted & kept for each request. The most recent rate limit stats can be accessed via the new `rateLimitStatistics`-attribute of the billomat api client:

| Attribute | Description |
|---|---|
| `rateLimitStatistics.lastResponseAt` | Date of the last response (this is where the statistics originated) |
| `rateLimitStatistics.limitRemaining` | Number of remaining requests |
| `rateLimitStatistics.limitResetAt` | Date, when the rate limit will be reset |